### PR TITLE
Update .taskcluster.yml for community cluster

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -31,8 +31,8 @@ tasks:
       - taskId: {$eval: as_slugid("lint_task")}
         created: {$fromNow: ''}
         deadline: {$fromNow: '1 hour'}
-        provisionerId: aws-provisioner-v1
-        workerType: github-worker
+        provisionerId: proj-relman
+        workerType: ci
         payload:
           maxRunTime: 3600
           image: python:3.7
@@ -53,8 +53,8 @@ tasks:
       - taskId: {$eval: as_slugid("packaging_test_task")}
         created: {$fromNow: ''}
         deadline: {$fromNow: '1 hour'}
-        provisionerId: aws-provisioner-v1
-        workerType: github-worker
+        provisionerId: proj-relman
+        workerType: ci
         payload:
           maxRunTime: 3600
           image: python:3.7
@@ -77,8 +77,8 @@ tasks:
           taskId: {$eval: as_slugid("version_check_task")}
           created: {$fromNow: ''}
           deadline: {$fromNow: '1 hour'}
-          provisionerId: aws-provisioner-v1
-          workerType: github-worker
+          provisionerId: proj-relman
+          workerType: ci
           payload:
             maxRunTime: 3600
             image: python:3.7
@@ -98,8 +98,8 @@ tasks:
       - taskId: {$eval: as_slugid("tests_task")}
         created: {$fromNow: ''}
         deadline: {$fromNow: '1 hour'}
-        provisionerId: aws-provisioner-v1
-        workerType: github-worker
+        provisionerId: proj-relman
+        workerType: ci
         payload:
           maxRunTime: 3600
           image: python:3.7
@@ -134,8 +134,8 @@ tasks:
             - secrets:get:project/relman/microannotate/deploy
           created: {$fromNow: ''}
           deadline: {$fromNow: '1 hour'}
-          provisionerId: aws-provisioner-v1
-          workerType: github-worker
+          provisionerId: proj-relman
+          workerType: ci
           payload:
             features:
               taskclusterProxy:


### PR DESCRIPTION
(context: [bug 1578411](https://bugzilla.mozilla.org/show_bug.cgi?id=1578411))

We'll still need to make the secrets in the new deployment in order for this to work but that is blocked on [bug 1593896](https://bugzilla.mozilla.org/show_bug.cgi?id=1593896) at the moment. I wanted to get this up for review to see if it made sense to you all. @La0 and @marco-c in particular.

*Note: this will fail until the github app that provides tc is switched which we would do right before we land this.*
