### PR TITLE
Use Mercurial 5.6

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -108,10 +108,7 @@ tasks:
           command:
             - "/bin/bash"
             - "-lcx"
-            - "apt-get -qq update &&
-               apt-get -qq install -y python-pip &&
-               python2 -m pip install --quiet mercurial==4.8 &&
-               curl -L https://github.com/mozilla/rust-code-analysis/releases/download/v0.0.18/rust-code-analysis-linux-x86_64.tar.gz | tar -C /usr/bin -xzv --strip=1 &&
+            - "curl -L https://github.com/mozilla/rust-code-analysis/releases/download/v0.0.18/rust-code-analysis-linux-x86_64.tar.gz | tar -C /usr/bin -xzv --strip=1 &&
                git clone --quiet ${repository} &&
                cd microannotate &&
                git -c advice.detachedHead=false checkout ${head_rev} &&

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
+mercurial==5.6
 pre-commit==2.9.3
 pytest==6.2.1


### PR DESCRIPTION
So we can stop installing Python 2 in the test task.